### PR TITLE
xdsconv.py and CChalf criterion

### DIFF
--- a/XDS/CChalf_xdsme.py
+++ b/XDS/CChalf_xdsme.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Sep 22 19:42:16 2017
+
+@author: lpecqueur
+"""
+
+import sys
+import os
+
+try:
+    import numpy
+except ImportError:
+    raise ImportError('''%s
+             Missing module numpy needed for option --CChalf
+             %s'''%('='*47,'='*47))
+try :
+    import scipy
+except :
+    raise ImportError('''%s
+             Missing module scipy needed for option --CChalf
+             %s'''%('='*47,'='*47))
+    
+###############################################################################
+class AimlessLogParser:
+    """ A Parser for log file from AIMLESS.
+    """
+    def __init__(self, filename="", run_dir="",
+                 verbose=False, raiseErrors=True):
+        self.results = {}
+        self.info = "AIMLESS Parser"
+        self.fileType = "AIMLESS"
+        self.verbose = verbose
+        self.resolution = []
+        self.CChalf= []
+        #
+        if not run_dir:
+            run_dir = "./"
+        self.run_dir = run_dir
+        #
+        full_filename = os.path.join(self.run_dir, filename)
+        #
+        if filename:
+            try:
+                fp = open(full_filename, "r")
+                self.lp = fp.read()
+                fp.close()
+            except:
+                raise IOError, "Can't read file: %s" % full_filename
+        else:
+            self.lp = ""
+
+        if full_filename.count("aimless.log"):
+            self.get_aimless_CChalf()
+        else:
+            if filename:
+                raise IOError, "Don't know how to parse file: %s" % \
+                               full_filename
+
+    def get_aimless_CChalf(self):
+        '''Parse AIMLESS log file for CChalf'''
+
+        ### Select Diffraction range.
+        sp1 = self.lp.index("  N  1/d^2    Dmid CCanom    Nanom   RCRanom   CC1/2   NCC1/2   Rsplit     CCfit CCanomfit   $$ $$")
+        sp2 = self.lp.index("                   CCanom    Nanom   RCRanom   CC1/2   NCC1/2   Rsplit     CCfit CCanomfit", sp1)
+        _table = self.lp[sp1:sp2].splitlines()[1:-2]
+        _table = [ map(float, l.split()[1:]) for l in _table ]
+        resolution, CChalf=[], []
+        for l in _table:
+            self.resolution.append(l[0])
+            self.CChalf.append(l[5])
+        return resolution, CChalf
+
+def func(x,d0,r):
+    '''x and y are lists of same size
+       x is 1/d**2, y is CC1/2
+       s is the resolution 1/d**2
+       d0 is 1/d**2 at half decrease
+       r is the steepness of the falloff
+    '''
+    from scipy import tanh
+    return 0.5*(1 -tanh((x - d0)/r))
+    
+def tanh_fit(Ex, Ey):
+    '''Ex and Ey are lists of same size
+       x is 1/d**2, y is CC1/2
+       s is the resolution 1/d**2
+       d0 is 1/d**2 at half decrease
+       r is the steepness of the falloff
+    '''
+    from scipy.optimize import curve_fit
+#    from pylab import *
+    
+    #initializing parameters
+    halffo=(max(Ey)-min(Ey))/2.
+    DELTA=(max(Ey)-min(Ey))
+    nearestpoint=int()
+    for i in Ey:
+        delta=abs(i - halffo)
+        if delta<DELTA:
+            DELTA=delta
+            nearestpoint=Ey.index(i)
+    d0=Ex[nearestpoint]
+    r=0.1
+    init_vals=[d0, r]
+    p, pcov = curve_fit(func,Ex,Ey, p0=init_vals)
+    d0_opt, r_opt=p[0], p[1]
+#    plot(Ex, Ey, "wo", Ex, func(Ex,*p), "r-") # Plot of the data and the fit
+    return [d0_opt, r_opt]
+ 
+def EstimateCC_NewHighRes(cutoff, d0, r, Ey):
+    '''Estimate a New High resolution
+    cutoff based on CC1/2=value
+    Ey is used to check if experimental data
+    contain a CC1/2<Threshold, if not
+    function is stopped
+    '''
+    from math import sqrt
+    from scipy import tanh
+    from numpy import linspace    
+
+#Check if calculation is sensible or not
+    if cutoff<=min(Ey):
+        print "ERROR, data don't reach this cutoff value...skipping"
+        return
+        
+    cutoff=float(cutoff)
+    d0=float(d0)
+    r=float(r)
+    HighRes=None
+
+    x = linspace(0.,1.,1001).tolist()
+    for val in x:
+        y=round(0.5*(1 -tanh((val - d0)/r)), 3)
+        if cutoff<=y<cutoff+0.03: #This condition is likely a source of problem
+            HighRes=sqrt(1/x[x.index(val)])
+            CalculatedCutoff=y
+    print "   ->  Suggested New High Resolution Limit: %.2f A for CC1/2= %.2f <-" %(HighRes, CalculatedCutoff)
+    del y    
+    return HighRes
+
+def CalculateAimlessHighRes(filename, run_dir="./", verbose=1, CChalf=0.3):
+    aimlessdata=AimlessLogParser(filename, run_dir, verbose) 
+    fit=tanh_fit(aimlessdata.resolution,aimlessdata.CChalf)
+    Newh=EstimateCC_NewHighRes(CChalf, fit[0], fit[1], aimlessdata.CChalf)
+    return Newh
+    
+if __name__ == "__main__":   
+#    inputfile=sys.argv[len(sys.argv)-1]
+    res = AimlessLogParser(filename="puck7_10_1_aimless.log", run_dir=".", verbose=1)
+    res2=tanh_fit(res.resolution,res.CChalf)
+    EstimateCC_NewHighRes(0.30, res2[0], res2[1], res.CChalf)

--- a/XDS/xdsconv.py
+++ b/XDS/xdsconv.py
@@ -46,7 +46,11 @@ usage   = """
                  -l pk or -l=pk becomes:
                  FP_pk, SIGFP_pk, DANO_pk ... in CCP4 mode
                  FP_pk, SIGFP_pk, F(+)_pk, SIGF(+)_pk, ... in PHASER mode
-
+	
+	 -free, or -free=
+		Generate the free reflection set with the given percent.
+		-free 10 or -free=10 will generate a 10 percent free reflection set.
+		
         free_hkl_to_inherit: is a reflection file containing a previously
                  selected set of free reflection to be kept in the newly
                  exported reflection file for calculation of unbiased Rfree.
@@ -1194,6 +1198,7 @@ if __name__ == '__main__':
     __force_no_free = False
     __force_output = False
     __label = ""
+    __freefrac = 0.05
     __quiet = False
 
     def _print(txt):
@@ -1222,6 +1227,12 @@ if __name__ == '__main__':
             __label = "_"+arg[3:]
         elif arg.count("-l"):
             __label = "_"+str(args[args.index("-l") + 1])
+        elif arg.count("-free="):
+            __freefrac = float(arg[6:])
+	    __freefrac = __freefrac/100
+        elif arg.count("-free"):
+            __freefrac = float(args[args.index("-free") + 1])
+	    __freefrac = __freefrac/100
         elif arg == "-f":
             __force_free = True
         elif arg == "-o":
@@ -1304,7 +1315,7 @@ if __name__ == '__main__':
     XC = Dumy()
     XC.file_type = "XDS_ASCII"
     XC.friedel_out = ""
-    XC.free_out = "GENERATE_FRACTION_OF_TEST_REFLECTIONS=0.05\n"
+    XC.free_out = "GENERATE_FRACTION_OF_TEST_REFLECTIONS=%3.2f\n"%(__freefrac)
     XC.free_lbl = "FreeR_flag"
     XC.free_code = "X"
     XC.merge_out = ""
@@ -1321,7 +1332,7 @@ if __name__ == '__main__':
     if __force_merge: XC.merge_out = "TRUE"
     if __force_unmerge: XC.merge_out = "FALSE"
     if __force_free:
-        XC.free_out = "GENERATE_FRACTION_OF_TEST_REFLECTIONS=0.05\n"
+        XC.free_out = "GENERATE_FRACTION_OF_TEST_REFLECTIONS=%3.2f\n"%(__freefrac)
         XC.free_lbl = "FreeR_flag"
         XC.free_code = "X"
     if __force_no_free:


### PR DESCRIPTION
Hello Pierre,

First apologies for my naive coding skills.

In xdsconv.py added the option to change free reflection ratio

For CChalf:
Created a module CChalf_xdsme.py that reads in AIMLESS LOG and calculate a cutoff defined in the command line by fitting CChalf=f(1/d2) with a tanh function.

In XDS.py, I slightly modified the function run_pre_correct() by adding an option cutres=True or False

I am not 100% satisfied with the CCHalf cutoff defined by:
"if cutoff<=y<cutoff+0.03: #This condition is likely a source of problem"

NOTE: I saw that CC1/2 from xds is different from the one calculated by aimless and phenix.merging_statistics. Indeed, CC1/2 from xds in CORRECT.LP was systematically higher than with aimless and phenix.

Ludovic.